### PR TITLE
Allow React version >17 to be as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "typescript": "4.5.4"
   },
   "peerDependencies": {
-    "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react": ">=17.0.2",
+    "react-dom": ">=17.0.2"
   }
 }


### PR DESCRIPTION
Hey 👋 
this PR introduces ability to use use joystick component with react v18, since npm/yarn fails (in strict mode) if peer dependencies are not met.