### PR TITLE
:sparkles: add stick size override, fixes #38

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Component Props - as described by IJoystickProps - all are optional
 import {JoystickShape} from "./shape.enum"; 
 interface IJoystickProps {
     size?: number;
+    stickSize?: number;
     baseColor?: string;
     stickColor?: string;
     disabled?: boolean;

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Component Props - as described by IJoystickProps - all are optional
 | Prop  | Type  | Description  |
 |---|---|---|
 | size  |  number |  The size in px of the Joystick base  |
+| stickSize  |  number |  The size in px of the Joystick stick (if unspecified, joystick size is relative to the `size` value |
 |  baseColor |  string |  The color of the Joystick base |
 | stickColor  |  string |  The color of the Stick |
 |  throttle | number  |  The [throttling](https://codeburst.io/throttling-and-debouncing-in-javascript-b01cad5c8edf) rate of the move callback |

--- a/src/Joystick.stories.tsx
+++ b/src/Joystick.stories.tsx
@@ -14,6 +14,8 @@ const joystickStories = storiesOf('Joystick Examples', module);
 
 joystickStories.add("Default joystick", () => <Joystick start={action("Started")} move={action("Moved")}
                                                         stop={action("Stopped")}/>);
+joystickStories.add("Default joystick with small stick", () => <Joystick stickSize={10} start={action("Started")} move={action("Moved")}
+    stop={action("Stopped")}/>);
 joystickStories.add("Default joystick with 50% minDistance", () => <Joystick minDistance={50} start={action("Started")} move={action("Moved")}
                                                         stop={action("Stopped")}/>);
 joystickStories.add("Control plane override", () => <Joystick start={action("Started")} controlPlaneShape={JoystickShape.Square} move={action("Moved")}

--- a/src/Joystick.tsx
+++ b/src/Joystick.tsx
@@ -5,6 +5,7 @@ import {shapeBoundsFactory} from "./shapes/shape.bounds.factory";
 
 export interface IJoystickProps {
     size?: number;
+    stickSize?: number;
     baseColor?: string;
     stickColor?: string;
     throttle?: number;
@@ -69,6 +70,8 @@ class Joystick extends React.Component<IJoystickProps, IJoystickState> {
     private readonly _baseRef: React.RefObject<HTMLDivElement> = React.createRef();
     private readonly _throttleMoveCallback: (data: IJoystickUpdateEvent) => void;
     private _baseSize: number;
+    private _stickSize: number;
+
     private _radius: number;
     private _parentRect: DOMRect;
     private _pointerId: number|null = null
@@ -350,7 +353,7 @@ class Joystick extends React.Component<IJoystickProps, IJoystickState> {
      */
     private _getStickStyle(): any {
         const stickColor: string = this.props.stickColor !== undefined ? this.props.stickColor : "#3D59AB";
-        const stickSize = `${this._baseSize / 1.5}px`;
+        const stickSize = this._stickSize ? `${this._stickSize}px` :`${this._baseSize / 1.5}px`;
 
         let stickStyle = {
             ...this.getStickShapeStyle(),
@@ -379,6 +382,7 @@ class Joystick extends React.Component<IJoystickProps, IJoystickState> {
 
     render() {
         this._baseSize = this.props.size || 100;
+        this._stickSize = this.props.stickSize;
         this._radius = this._baseSize / 2;
         const baseStyle = this._getBaseStyle();
         const stickStyle = this._getStickStyle();


### PR DESCRIPTION
Ability to override the size of the joystick using the `stickSize` prop